### PR TITLE
Added Byte Order Mark detection so files exported from Excel can be i…

### DIFF
--- a/dataload/reader.py
+++ b/dataload/reader.py
@@ -46,12 +46,19 @@ class CsvBatchReader(BaseBatchReader):
         self.header = None
         self.start_at = start_at
         self.plural_processor = None
+        self.fileHasBOM = False
 
         if self.batch_size <=2:
             raise Exception("Batch size must be greater than 2.")
 
     def utf8_validate(self):
-        logger.info("Validating UTF-8 encoding")
+        logger.info("Validating UTF-8 encoding and checking for Byte Order Mark")
+        # check for BOM first - usually appears if file was exported from MS Excel
+        with open(self.csv_file, "rb") as f:
+            if (f.read(3) == b'\xef\xbb\xbf'):
+                logger.info("Byte Order Mark detected.")
+                self.fileHasBOM = True
+            f.close()
         f = codecs.open(self.csv_file, encoding='utf8', errors='strict')
         line_number = 1
         try:
@@ -64,6 +71,9 @@ class CsvBatchReader(BaseBatchReader):
     def __iter__(self):
         self.utf8_validate()
         with open(self.csv_file, encoding="utf-8") as f:
+            # if the file has a BOM, start reading after those bytes
+            if self.fileHasBOM:
+                f.seek(3)
             reader = csv.reader(f, delimiter=self.delimiter)
             batch = []
             batch_number = 0


### PR DESCRIPTION
…mported

This fixes a long-standing issue where customers export their CSV file from Excel, which adds the Byte Order Mark to the beginning of the file and breaks our import because the first item in the header will no longer match the actual schema attribute.

This issue forced customers to use Libre Office and caused many significant delays in imports.